### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,17 @@
 language: python
 python:
   - "2.7"
+  - "3.6"
+matrix:
+  allow_failures:
+    - python: "3.6"
 install:
   - pip install -r requirements.txt
+  - pip install flake8
+before_script:
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 script:
   - pytest

--- a/Source/Module/communicationDetailsFetch.py
+++ b/Source/Module/communicationDetailsFetch.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Library Import
 import ipwhois
 from dns import reversename, resolver
@@ -69,9 +70,9 @@ class trafficDetailsFetch():
 
 def main():
     capture = pcapReader.pcapReader("lanExample.pcap")
-    print "read"
+    print("read")
     details = trafficDetailsFetch(capture.packetDB)
-    print details.communication_details
-    print "\n"
+    print(details.communication_details)
+    print("\n")
 
 #main()

--- a/Source/Module/deviceDetailsFetch.py
+++ b/Source/Module/deviceDetailsFetch.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Library Import
 import urllib2
 import json
@@ -30,7 +31,7 @@ def main():
     pcapfile = pcapReader.pcapReader('test.pcap')
     for ip in pcapfile.packetDB:
         macObj = fetchDeviceDetails(pcapfile.packetDB[ip])
-        print macObj.oui_identification()
+        print(macObj.oui_identification())
 #main()
 
 # MAC Oui Identification Module

--- a/Source/Module/maliciousTrafficIdentifier.py
+++ b/Source/Module/maliciousTrafficIdentifier.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Custom Module Import
 import pcapReader
 
@@ -28,10 +29,10 @@ class maliciousTrafficIdentifier:
 
 def main():
     malicious_capture = pcapReader.pcapReader("torexample.pcapng")
-    print malicious_capture.packetDB
+    print(malicious_capture.packetDB)
     dns_details = {}
     mal_identify = maliciousTrafficIdentifier(malicious_capture.packetDB, dns_details)
-    print mal_identify.possible_malicious_traffic
+    print(mal_identify.possible_malicious_traffic)
 
 #main()
 

--- a/Source/Module/pcapReader.py
+++ b/Source/Module/pcapReader.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Import Section - Dependant Module inclusion
 from scapy.all import *
 from netaddr import *
@@ -125,5 +126,5 @@ class pcapReader():
 # Module Driver
 def main():
     pcapfile = pcapReader('lanExample.pcap')
-    print pcapfile.packetDB
+    print(pcapfile.packetDB)
 #main()

--- a/Source/Module/plotLanNetwork.py
+++ b/Source/Module/plotLanNetwork.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 #File Import
 import pcapReader
 import communicationDetailsFetch
@@ -80,7 +81,7 @@ class plotLan:
 
         f.attr('node', shape='circle')
 
-        print "Starting Graph Plotting"
+        print("Starting Graph Plotting")
 
         if option == "All":
             # add nodes
@@ -122,7 +123,7 @@ class plotLan:
                             try:
                                f.edge(node, 'defaultGateway', label='HTTPS: ' +dest+": "+self.name_servers[node]["ip_details"][dest]["dns"], color = "blue")
                             except:
-                                print self.name_servers[node]
+                                print(self.name_servers[node])
 
 
         if option == "Tor":
@@ -150,7 +151,7 @@ class plotLan:
 def main():
     # draw example
     pcapfile = pcapReader.pcapReader('lanExample.pcap')
-    print "Reading Done...."
+    print("Reading Done....")
     details = communicationDetailsFetch.trafficDetailsFetch(pcapfile.packetDB)
     network = plotLan(pcapfile.packetDB, "network12345", details.communication_details,"HTTPS")
 

--- a/Source/Module/reportGen.py
+++ b/Source/Module/reportGen.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Report Generation
 import os, json
 from scapy.all import *
@@ -13,21 +14,21 @@ class reportGen:
         try:
             text_handle = open(self.directory + "/communicationDetailsReport.txt", "w")
         except Exception as e:
-            print "Could not create the report text file !!!!! Please debug error %s" % (str(e.message))
+            print("Could not create the report text file !!!!! Please debug error %s" % (str(e.message)))
         text_handle.write("CommunicationDetails: %s" % json.dumps(commDB, indent=2,sort_keys=True))
 
     def deviceDetailsReport(self, deviceDetails):
         try:
             text_handle = open(self.directory + "/deviceDetailsReport.txt", "w")
         except Exception as e:
-            print "Could not create the report text file !!!!! Please debug error %s" % (str(e.message))
+            print("Could not create the report text file !!!!! Please debug error %s" % (str(e.message)))
         text_handle.write("deviceDetails: %s" % json.dumps(deviceDetails, indent=2,sort_keys=True))
 
     def packetDetails(self, packetDB):
         try:
             text_handle = open(self.directory + "/packetDetailsReport.txt", "w")
         except Exception as e:
-            print "Could not create the report text file !!!!! Please debug error %s" % (str(e.message))
+            print("Could not create the report text file !!!!! Please debug error %s" % (str(e.message)))
         for ip in packetDB:
             if "TCP" in packetDB[ip]:
                 if "HTTP" in packetDB[ip]["TCP"]:

--- a/Source/Module/torTrafficHandle.py
+++ b/Source/Module/torTrafficHandle.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Custom Module Imports
 import pcapReader
 
@@ -36,9 +37,9 @@ class torTrafficHandle():
 
 def main():
      tor_capture = pcapReader.pcapReader("torexample.pcapng")
-     print tor_capture.packetDB
+     print(tor_capture.packetDB)
      tor_identify = torTrafficHandle(tor_capture.packetDB)
-     print tor_identify.possible_tor_traffic
+     print(tor_identify.possible_tor_traffic)
 
 #main()
 

--- a/Source/Module/userInterface.py
+++ b/Source/Module/userInterface.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from Tkinter import *
 import ttk
 import tkMessageBox
@@ -118,7 +119,7 @@ class pcapXrayGui:
         self.yscrollbar.config(command=canvas.yview)
 
     def map_select(self, *args):
-        print self.option.get()
+        print(self.option.get())
         self.generate_graph()
 
 def main():


### PR DESCRIPTION
Make the minimal, safe changes required to convert the repo's code to be syntax compatible with both Python 2 and Python 3.  There may be other changes required to complete a port to Python 3 but this PR is a minimal, safe first step.

Run: [futurize --stage1 -w **/*.py](http://python-future.org/futurize_cheatsheet.html)

    See Stage 1: "safe" fixes http://python-future.org/automatic_conversion.html#stage-1-safe-fixes
